### PR TITLE
Enforce page-sized FlashStorage sizes

### DIFF
--- a/libraries/FlashStorage/src/FlashStorage.h
+++ b/libraries/FlashStorage/src/FlashStorage.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
  * Copyright (c) 2020  GigaDevice Semiconductor Inc.
- *               2021  Keyboard.io, Inc.
+ *               2021, 2022  Keyboard.io, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -38,7 +38,8 @@ class FlashStorage
     private:
         uint8_t buffer_[_storage_size];
         static constexpr uint32_t fmc_base_address = 0x08000000;
-        static constexpr uint32_t bank0_end = fmc_base_address + 512 * 1024 - 1;
+        static constexpr uint32_t bank0_size = 512 * 1024;
+        static constexpr uint32_t bank0_end = fmc_base_address + bank0_size - 1;
         static constexpr uint32_t fmc_end_address = fmc_base_address + _fmc_end;
         static constexpr uint32_t data_area_start = fmc_end_address - _storage_size;
 

--- a/libraries/FlashStorage/src/FlashStorage.h
+++ b/libraries/FlashStorage/src/FlashStorage.h
@@ -35,6 +35,16 @@ template <uint32_t _storage_size,
           uint32_t _fmc_end = ARDUINO_UPLOAD_MAXIMUM_SIZE>
 class FlashStorage
 {
+    // We need the flash storage to be page aligned, and to span full pages.
+    //
+    // For the sake of simplicity, we only assert on size, and do so assuming
+    // that the page size is 4k. Technically, bank0 pages are only 2k, but
+    // calculating whether the storage size is allowed with different page sizes
+    // involved - at compile time - is trickier than what its worth. As such,
+    // we'll enforce 4k pages here.
+    static_assert(_storage_size % 4096 == 0,
+                  "Storage must be page aligned, with a size multiple of 4096.");
+
     private:
         uint8_t buffer_[_storage_size];
         static constexpr uint32_t fmc_base_address = 0x08000000;


### PR DESCRIPTION
FlashStorage **must** be both page aligned, and span full pages. We can't erase and rewrite partial pages, and we must not touch the area outside of the reserved one. If we try to erase and then rewrite partial pages, the whole partial page operation will fail. Therefore, we need to ensure that the storage size is a multiple of our page size.

This patchset does just that, with the caveat that we enforce the size as if all pages were 4k, even if our storage is (at least partially) in bank0. This is to make the implementation trivial and not require complex computations at compile-time.

This is the same as CommunityGD32Cores/ArduinoCore-GD32#60, but rebased onto our main.