### PR TITLE
FlashStorage: Fix the bounds checking in FlashStorage::write()

### DIFF
--- a/libraries/FlashStorage/src/FlashStorage.h
+++ b/libraries/FlashStorage/src/FlashStorage.h
@@ -83,7 +83,7 @@ class FlashStorage
         void write(uint32_t offset, const uint8_t *data, uint32_t data_size)
         {
             // If we're out of bounds, or try to write too much, bail out.
-            if (offset > _storage_size || data_size > _storage_size)
+            if ((offset + data_size) > _storage_size)
                 return;
 
             for (uint32_t i = 0; i < data_size; i++) {


### PR DESCRIPTION
The bounds checking in `FlashStorage::write()` was insufficient, it only checked whether the offset is out of bounds, or if the data size is bigger than the storage space. It did not account for the case where offset is within bounds, data size is smaller than storage size, but there isn't sufficient space for data size starting at offset.

To fix that, correct and simplify the bounds checking: we'll bail out if `offset + data_size` is larger than `_storage_size`. This covers both previous cases that were covered, and the third case too, which previously was not.
