### PR TITLE
Revert "Enable serial autoflush"

### DIFF
--- a/cores/arduino/CDCACM.cpp
+++ b/cores/arduino/CDCACM.cpp
@@ -76,7 +76,7 @@ bool CDCACM_::setup(arduino::USBSetup& setup)
         } else if (setup.bRequest == CDC_SET_CONTROL_LINE_STATE) {
             this->lineState = setup.wValueL;
             if (this->lineState > 0) {
-                usbd_int_fops = &usb_inthandler;
+                // usbd_int_fops = &usb_inthandler;
             } else {
                 usbd_int_fops = nullptr;
             }


### PR DESCRIPTION
This reverts commit 74d9e51b3d54205faec17a905132fef4116327af, because it caused a whole lot of issues, including leading up to complete lockups under certain common scenarios.

The revert fixes keyboardio/Chrysalis#985.