### PR TITLE
Fix some EPBuffer read issues

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -108,7 +108,7 @@ void EPBuffer<L>::init(uint8_t ep)
 {
     this->ep = ep;
     this->reset();
-    this->rxWaiting = true;
+    this->rxWaiting = false;
     this->txWaiting = false;
 }
 
@@ -209,6 +209,7 @@ void EPBuffer<L>::enableOutEndpoint()
 {
     // Don’t attempt to read from the endpoint buffer until it’s
     // ready.
+    if (this->rxWaiting) return;
     this->rxWaiting = true;
 
     this->reset();


### PR DESCRIPTION
I admit, I have absolutely no idea what this does, it's a change from @bjc, which fixes both the data loss / corruption issues we've been seeing on the Model 100 when used with Chrysalis, and it also fixes the case where the communication completely stalled when Chrysalis sent more than ~64 bytes at a time.

Once we have this upstreamed and explained, we'll want to replace this commit with the final one.