### PR TITLE
implement remote wakeup

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -656,11 +656,15 @@ int USBCore_::send(uint8_t ep, const void* data, int len)
      * suspend (long-"J-like") or resume (long-K). It also implies
      * that SPSIF similarly does not distinguish these line states.
      */
+    usb_disable_interrupts();
     if (usbd->cur_status == USBD_SUSPENDED && usbd->pm.remote_wakeup) {
-        usbd_remote_wakeup_active(usbd);
         // Work around low-level USBD firmware bug
         usbd->cur_status = usbd->backup_status;
+        usb_enable_interrupts();
+        usbd_remote_wakeup_active(usbd);
         return -1;
+    } else {
+        usb_enable_interrupts();
     }
 #endif
     // Discard data instead of blocking indefinitely, if unconfigured

--- a/cores/arduino/gd32/usbd_conf.h
+++ b/cores/arduino/gd32/usbd_conf.h
@@ -19,6 +19,9 @@
 /* link power mode support */
 #undef LPM_ENABLED
 
+/* Enable sending remote wakeup */
+#define USBD_REMOTE_WAKEUP
+
 /*
  * TODO: I’m currently using the maximum values allowed by the spec
  * for available interfaces and endpoints, because I can’t know this


### PR DESCRIPTION
In USBCore_::send, implement sending remote wakeup signaling when
attempting to send from an endpoint. Work around a bug in the low-level
USBD firmware. Also return an error instead of blocking when not
configured.

Based on #6, because that's very helpful for visual feedback for testing and debugging.