### PR TITLE
send at least ZLP on successful control read

### DIFF
--- a/cores/arduino/USBCore.h
+++ b/cores/arduino/USBCore.h
@@ -183,6 +183,8 @@ class USBCore_
         // TODO: verify that this only applies to the control endpoint’s use of wLength
         // I think this is only on the setup packet, so it should be fine.
         uint16_t maxWrite = 0;
+        // Whether a control write has occurred during a control transaction
+        bool controlWritten;
 
         /*
          * Pointers to the transaction routines specified by ‘usbd_init’.


### PR DESCRIPTION
The KeyboardioHID library implicitly relied on underdocumented behavior of the AVR USB core to always send at least a zero-length packet for successful control read transfers. GD32 was timing out these transfers instead.
