### PR TITLE
fix clearing endpoint halt

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -450,6 +450,11 @@ class ClassCore
                 } else if (sent < 0) {
                     return REQ_NOTSUPP;
                 }
+            } else if ((setup.bmRequestType & USB_RECPTYPE_MASK) == USB_RECPTYPE_EP) {
+                uint8_t ep = EP_ID(setup.wIndex);
+                // Reset endpoint state on ClearFeature(EndpointHalt)
+                EPBuffers().buf(ep).init(ep);
+                return REQ_SUPP;
             } else {
 #ifdef USBD_USE_CDC
                 if (CDCACM().setup(setup))

--- a/system/GD32F30x_firmware/GD32F30x_usbd_library/usbd/Source/usbd_lld_core.c
+++ b/system/GD32F30x_firmware/GD32F30x_usbd_library/usbd/Source/usbd_lld_core.c
@@ -412,7 +412,7 @@ static void usbd_ep_stall_clear (usb_dev *udev, uint8_t ep_addr)
         udev->transc_in[ep_num].ep_stall = 0U;
 
         /* clear endpoint stall status */
-        USBD_EP_TX_STAT_SET(ep_num, EPTX_VALID);
+        USBD_EP_TX_STAT_SET(ep_num, EPTX_NAK);
     } else {
         /* clear endpoint data toggle bit */
         USBD_RX_DTG_CLEAR(ep_num);
@@ -420,7 +420,7 @@ static void usbd_ep_stall_clear (usb_dev *udev, uint8_t ep_addr)
         udev->transc_out[ep_num].ep_stall = 0U;
 
         /* clear endpoint stall status */
-        USBD_EP_RX_STAT_SET(ep_num, EPRX_VALID);
+        USBD_EP_RX_STAT_SET(ep_num, EPRX_NAK);
     }
 }
 


### PR DESCRIPTION
Patch the low-level firmware to set the endpoint to NAK instead of ACK when clearing an endpoint halt. Prevents a bus reset loop situation with Windows due to an unexpectedly large queued IN packet.

Also, add a handler to reset our endpoint buffer state when the low-level firmware clears an endpoint halt.
