### PR TITLE
add USBCore_::configured

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -1017,4 +1017,9 @@ bool USBCore_::isSuspended()
 {
     return USBCore().usbDev().cur_status == USBD_SUSPENDED;
 }
+
+bool USBCore_::configured()
+{
+    return USBCore().usbDev().config != 0;
+}
 #endif

--- a/cores/arduino/USBCore.h
+++ b/cores/arduino/USBCore.h
@@ -148,6 +148,7 @@ class USBCore_
         void connect();
         void disconnect();
         bool isSuspended();
+        bool configured();
 
         /*
          * PluggableUSB interface.

--- a/system/GD32F30x_firmware/GD32F30x_usbd_library/device/Include/usbd_core.h
+++ b/system/GD32F30x_firmware/GD32F30x_usbd_library/device/Include/usbd_core.h
@@ -153,7 +153,7 @@ typedef struct {
 /* USB core driver struct */
 struct _usb_dev {
     /* basic parameters */
-    uint8_t         config;
+    __IO uint8_t    config;
     uint8_t         dev_addr;
 
     __IO uint8_t    cur_status;

--- a/system/GD32F30x_firmware/GD32F30x_usbd_library/usbd/Source/usbd_lld_core.c
+++ b/system/GD32F30x_firmware/GD32F30x_usbd_library/usbd/Source/usbd_lld_core.c
@@ -229,6 +229,7 @@ static void usbd_ep_reset (usb_dev *udev)
     USBD_DADDR = DADDR_USBEN;
 
     udev->cur_status = (uint8_t)USBD_DEFAULT;
+    udev->config = 0U;
 }
 
 /*!


### PR DESCRIPTION
This makes it possible for KeyboardioHID to poll for a bus reset on GD32.

This required fixing some low-level USBD firmware bugs.