### PR TITLE
use low-level API for control writes

### DIFF
--- a/system/GD32F30x_firmware/GD32F30x_usbd_library/device/Source/usbd_transc.c
+++ b/system/GD32F30x_firmware/GD32F30x_usbd_library/device/Source/usbd_transc.c
@@ -110,7 +110,15 @@ void _usb_out0_transc (usb_dev *udev, uint8_t ep_num)
 {
     if (((uint8_t)USBD_CONFIGURED == udev->cur_status) && (udev->class_core->ctlx_out != NULL)) {
         /* device class handle */
-        (void)udev->class_core->ctlx_out(udev);
+        /*
+         * bugfix: actually check return value from ctlx_out. This allows
+         * the Arduino core to defer the OUT setup validation to ctlx_out,
+         * and for the Arduino core's recvControl to work as expected.
+         */
+        if (USBD_OK != udev->class_core->ctlx_out(udev)) {
+            usb_stall_transc(udev);
+            return;
+        };
     }
 
     usb_transc_config(&udev->transc_out[ep_num], NULL, 0U, 0U);


### PR DESCRIPTION
Use more of the low-level USBD API to handle control writes. This depends on a bugfix to the low-level firmware. Defer the validation of the control request setup header until the Data OUT stage has completed. This allows the recvControl to be called as expected from within the Arduino API setup handlers of the class-specific drivers. There is a fixed-size static buffer to receive the Data OUT payload, shared with the Data IN payload.

This is part of a series of changes that will eventually allow us to remove a large amount of local duplication of the vendor ISR code. That kind of local code duplication is likely to be risky and introduce race conditions, no matter how carefully it's implemented.
