### PR TITLE
fix some I2C hangs

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -32,7 +32,7 @@ keyboardio_model_100.upload_port.pid.1=0x0005
 # These two definitions set -D flags to the compiler to get the right code compiled for our MCU 
 keyboardio_model_100.build.series=GD32F30x
 keyboardio_model_100.build.product_line=GD32F30X_XD
-keyboardio_model_100.build.extra_flags={build.usb_flags} -DUSBCON -DUSBD_USE_CDC -DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Keyboardio-Model100.h" -DWIRE_I2C_FLAG_TIMEOUT_ADDR_ACK=0xF0U
+keyboardio_model_100.build.extra_flags={build.usb_flags} -DUSBCON -DUSBD_USE_CDC -DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Keyboardio-Model100.h"
 
 keyboardio_model_100.build.variant=keyboardio_model_100
 keyboardio_model_100.upload.openocd_script=target/stm32f1x.cfg

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -52,6 +52,7 @@ class TwoWire : public Stream
 
         uint8_t ownAddress;
         i2c_t _i2c;
+        uint32_t clock;
 
         static void (*user_onRequest)(void);
         static void (*user_onReceive)(int);

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -94,8 +94,6 @@ void i2c_attach_slave_tx_callback(i2c_t *obj, void (*function)(void));
 i2c_status_enum i2c_slave_write_buffer(i2c_t *obj, uint8_t *data, uint16_t size);
 /* set I2C clock speed */
 void i2c_set_clock(i2c_t *obj, uint32_t clock_hz);
-/* Check to see if the I2C bus is busy */
-i2c_status_enum _i2c_busy_wait(i2c_t *obj);
 
 
 


### PR DESCRIPTION
Reset the I2C peripheral on a BUSY condition, because it will probably not clear up otherwise. This was causing permanent lockups on bus glitches.

Rework a bunch of the timeout loops to exit early when detecting an error, instead of waiting for the full timeout period. This speeds up a lot of common cases, such as a NACK due to a missing target.

Decrease a lot of the timeouts. The previous default was effectively over 500ms long, which is kind of excessive for a keyboard with a 1ms polling interval.