### PR TITLE
add support to configure sysclk in boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -76,7 +76,7 @@ keyboardio_micro.upload.maximum_data_size=98304
 # These two definitions set -D flags to the compiler to get the right code compiled for our MCU 
 keyboardio_micro.build.series=GD32F30x
 keyboardio_micro.build.product_line=GD32F30X_XD
-keyboardio_micro.build.extra_flags={build.usb_flags} -DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Keyboardio-Micro.h" 
+keyboardio_micro.build.extra_flags={build.usb_flags} -DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Keyboardio-Micro.h" "-D__SYSTEM_CLOCK_120M_PLL_IRC8M=(uint32_t)(120000000)"
 
 keyboardio_micro.build.variant=keyboardio_micro
 keyboardio_micro.upload.openocd_script=target/stm32f1x.cfg

--- a/system/GD32F30x_firmware/CMSIS/GD/GD32F30x/Source/system_gd32f30x.c
+++ b/system/GD32F30x_firmware/CMSIS/GD/GD32F30x/Source/system_gd32f30x.c
@@ -45,7 +45,7 @@
 //#define __SYSTEM_CLOCK_48M_PLL_IRC8M            (uint32_t)(48000000)
 //#define __SYSTEM_CLOCK_72M_PLL_IRC8M            (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_108M_PLL_IRC8M           (uint32_t)(108000000)
-#define __SYSTEM_CLOCK_120M_PLL_IRC8M           (uint32_t)(120000000)
+//#define __SYSTEM_CLOCK_120M_PLL_IRC8M           (uint32_t)(120000000)
 
 /* use HXTAL(XD series CK_HXTAL = 8M, CL series CK_HXTAL = 25M) */
 //#define __SYSTEM_CLOCK_HXTAL                    (uint32_t)(__HXTAL)


### PR DESCRIPTION
Also delete the override in system_gd32f30x.c, because it's no longer needed.