### PR TITLE
pre-build USB config descriptors

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -224,6 +224,7 @@ void EPBuffer<L>::flush()
         return;
     }
     this->currentlyFlushing = true;
+    USBCore().logEP('_', this->ep, '>', this->len());
 
     // Only attempt to send if the device is configured enough.
     switch (USBCore().usbDev().cur_status) {
@@ -245,7 +246,8 @@ void EPBuffer<L>::flush()
             // Only start the next transmission if the device hasn't been
             // reset.
             this->txWaiting = true;
-            USBCore().usbDev().drv_handler->ep_write((uint8_t*)this->buf, this->ep, this->len());
+            usbd_ep_send(&USBCore().usbDev(), this->ep, (uint8_t *)this->buf, this->len());
+            USBCore().logEP('>', this->ep, '>', this->len());
         }
         break;
     }
@@ -433,6 +435,7 @@ class ClassCore
         // Called when ep0 gets a SETUP packet after configuration.
         static uint8_t reqProcess(usb_dev* usbd, usb_req* req)
         {
+            USBCore().logStatus("ClassCore");
             (void)usbd;
 
             // Stash setup contents for later use by ctlOut
@@ -535,6 +538,7 @@ static void (*resetHook)();
 void (*oldResetHandler)(usb_dev *usbd);
 void handleReset(usb_dev *usbd)
 {
+    USBCore().logStatus("Reset");
     EPBuffers().init();
     if (resetHook) {
         resetHook();
@@ -547,8 +551,27 @@ void USBCore_::setResetHook(void (*hook)())
     resetHook = hook;
 }
 
+void (*oldSuspendHandler)();
+void handleSuspend()
+{
+    USBCore().logStatus("Suspend");
+    oldSuspendHandler();
+}
+
+void (*oldResumeHandler)();
+void handleResume()
+{
+    usb_disable_interrupts();
+    USBCore().logStatus("Resume");
+    usb_enable_interrupts();
+    oldResumeHandler();
+}
+
 USBCore_::USBCore_()
 {
+#ifdef USBCORE_TRACE
+    Serial1.begin(USBCORE_TRACE_SPEED);
+#endif
     /*
      * Use global ‘usbd’ here, instead of wrapped version, to avoid
      * initialization loop.
@@ -559,6 +582,12 @@ USBCore_::USBCore_()
     oldResetHandler = usbd.drv_handler->ep_reset;
     usbd.drv_handler->ep_reset = handleReset;
 
+    oldSuspendHandler = usbd.drv_handler->suspend;
+    usbd.drv_handler->suspend = handleSuspend;
+
+    oldResumeHandler = usbd.drv_handler->suspend_leave;
+    usbd.drv_handler->suspend_leave = handleResume;
+
     this->oldTranscSetup = usbd.ep_transc[0][TRANSC_SETUP];
     usbd.ep_transc[0][TRANSC_SETUP] = USBCore_::transcSetupHelper;
 
@@ -567,6 +596,52 @@ USBCore_::USBCore_()
 
     this->oldTranscIn = usbd.ep_transc[0][TRANSC_IN];
     usbd.ep_transc[0][TRANSC_IN] = USBCore_::transcInHelper;
+}
+
+void USBCore_::logEP(char kind, uint8_t ep, char dir, size_t len)
+{
+#ifdef USBCORE_TRACE
+    Serial1.print(USBD_EPxCS(ep), 16);
+    Serial1.print(kind);
+    Serial1.print(ep);
+    Serial1.print(dir);
+    Serial1.print(len);
+    if (ep == 0) {
+        usbd_ep_ram *btable_ep = (usbd_ep_ram *)(USBD_RAM + 2 * (BTABLE_OFFSET & 0xFFF8));
+        auto rxcnt = &btable_ep[0].rx_count;
+        Serial1.print(' ');
+        Serial1.print(USBD_EPxCS(ep), 16);
+        Serial1.print('(');
+        Serial1.print(*rxcnt & EPRCNT_CNT);
+        Serial1.print(')');
+    }
+    Serial1.println();
+    // Serial1.flush();
+#endif
+}
+
+void USBCore_::hexDump(char prefix, const uint8_t *buf, size_t len)
+{
+#ifdef USBCORE_TRACE
+    Serial1.print(prefix);
+    for (size_t i = 0; i < len; i++) {
+        if (i != 0) {
+            Serial1.print(' ');
+        }
+        Serial1.print(buf[i] >> 4, 16);
+        Serial1.print((buf[i] & 0x0f), 16);
+    }
+    Serial1.println();
+    // Serial1.flush();
+#endif
+}
+
+void USBCore_::logStatus(const char *status)
+{
+#ifdef USBCORE_TRACE
+    Serial1.println(status);
+    // Serial1.flush();
+#endif
 }
 
 void USBCore_::connect()
@@ -592,6 +667,8 @@ void USBCore_::disconnect()
 // Must be called via ISR, or when the endpoint isn't in VALID status.
 int USBCore_::sendControl(uint8_t flags, const void* data, int len)
 {
+    USBCore().logEP('+', 0, '>', len);
+
     uint8_t* d = (uint8_t*)data;
     auto usbd = &USBCore().usbDev();
     auto l = min(len, this->maxWrite);
@@ -682,9 +759,13 @@ int USBCore_::send(uint8_t ep, const void* data, int len)
     auto wrote = 0;
     auto usbd = &USBCore().usbDev();
 
+    // usb_disable_interrupts();
+    // USBCore().logEP('+', ep, '>', len);
+    // usb_enable_interrupts();
 #ifdef USBD_REMOTE_WAKEUP
     usb_disable_interrupts();
     if (usbd->cur_status == USBD_SUSPENDED && usbd->pm.remote_wakeup) {
+        USBCore().logStatus("Remote wakeup");
         usb_enable_interrupts();
         usbd_remote_wakeup_active(usbd);
     } else {
@@ -746,6 +827,8 @@ int USBCore_::flush(uint8_t ep)
         auto usbd = &USBCore().usbDev();
         usbd->transc_in[0].xfer_buf = ctlBuf;
         usbd->transc_in[0].xfer_len = ctlIdx;
+        USBCore().logEP('_', 0, '>', ctlIdx);
+        // USBCore().hexDump('>', ctlBuf, ctlIdx);
     } else {
         EPBuffers().buf(ep).flush();
     }
@@ -804,6 +887,8 @@ void USBCore_::transcSetup(usb_dev* usbd, uint8_t ep)
         return;
     }
 
+    USBCore().hexDump('^', (uint8_t *)&usbd->control.req, 8);
+
     this->maxWrite = usbd->control.req.wLength;
     switch (usbd->control.req.bmRequestType & USB_REQTYPE_MASK) {
         /* standard device request */
@@ -857,19 +942,26 @@ void USBCore_::transcSetup(usb_dev* usbd, uint8_t ep)
 // Called in interrupt context.
 void USBCore_::transcOut(usb_dev* usbd, uint8_t ep)
 {
+    auto transc = &usbd->transc_out[ep];
+    auto count = transc->xfer_count;
     EPBuffers().buf(ep).transcOut();
+    USBCore().logEP(':', ep, '<', count);
     if (ep == 0) {
         this->oldTranscOut(usbd, ep);
     }
+    USBCore().logEP('.', ep, '<', count);
 }
 
 // Called in interrupt context.
 void USBCore_::transcIn(usb_dev* usbd, uint8_t ep)
 {
+    auto transc = &usbd->transc_in[ep];
+    USBCore().logEP(':', ep, '>', transc->xfer_count);
     EPBuffers().buf(ep).transcIn();
-    if (ep == 0) {
+     if (ep == 0) {
         this->oldTranscIn(usbd, ep);
     }
+    transc->xfer_count = 0;
 }
 
 void USBCore_::sendDeviceConfigDescriptor()

--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -120,7 +120,7 @@ static uint8_t* stringDescs[] = {
 
 usb_desc desc = {
     .dev_desc    = (uint8_t *)&devDesc,
-    .config_desc = (uint8_t *)&configDesc,
+    .config_desc = nullptr,
     .bos_desc    = nullptr,
     .strings     = stringDescs
 };
@@ -440,6 +440,7 @@ class ClassCore
 
             // Stash setup contents for later use by ctlOut
             memcpy(&setup, req, sizeof(setup));
+            USBCore().setupClass(req->wLength);
             if (setup.bRequest == USB_GET_DESCRIPTOR) {
                 auto sent = PluggableUSB().getDescriptor(setup);
                 if (sent > 0) {
@@ -539,7 +540,9 @@ void (*oldResetHandler)(usb_dev *usbd);
 void handleReset(usb_dev *usbd)
 {
     USBCore().logStatus("Reset");
+    USBCore().setupClass(0);
     EPBuffers().init();
+    USBCore().buildDeviceConfigDescriptor();
     if (resetHook) {
         resetHook();
     }
@@ -652,6 +655,16 @@ void USBCore_::connect()
 void USBCore_::disconnect()
 {
     usb_disconnect();
+}
+
+void USBCore_::setupClass(uint16_t wLength)
+{
+    this->ctlIdx = 0;
+    this->ctlOutLen = 0;
+    this->maxWrite = wLength;
+    auto usbd = &USBCore().usbDev();
+    usb_transc_config(&usbd->transc_in[0], NULL, 0, 0);
+    usb_transc_config(&usbd->transc_out[0], NULL, 0, 0);
 }
 
 // Send ‘len’ octets of ‘d’ through the control pipe (endpoint 0).
@@ -858,85 +871,15 @@ usb_dev& USBCore_::usbDev()
     return usbd;
 }
 
-/*
- * TODO: This is a heck of a monkey patch that just seems to get more
- * fragile every time functionality is needed in the rest of the
- * Arduino core.
- *
- * It was initially intended to try and use as much of the firmware
- * library’s code as possible, but it’s just not a good fit, and
- * should probably be scrapped and started again now that more of its
- * scope is known.
- */
+/* Log the raw Setup stage data packet */
 void USBCore_::transcSetup(usb_dev* usbd, uint8_t ep)
 {
-    (void)ep;
-    this->ctlIdx = 0;
-    this->ctlOutLen = 0;
-    // Configure empty transactions for default
-    usb_transc_config(&usbd->transc_in[0], NULL, 0, 0);
-    usb_transc_config(&usbd->transc_out[0], NULL, 0, 0);
+    USBCore().logEP(':', ep, '^', USB_SETUP_PACKET_LEN);
+    auto count = usbd->drv_handler->ep_read((uint8_t *)(&usbd->control.req), 0, (uint8_t)EP_BUF_SNG);
+    USBCore().hexDump('^', (uint8_t *)&usbd->control.req, count);
 
-    usb_reqsta reqstat = REQ_NOTSUPP;
-
-    uint16_t count = usbd->drv_handler->ep_read((uint8_t *)(&usbd->control.req), 0, (uint8_t)EP_BUF_SNG);
-
-    if (count != USB_SETUP_PACKET_LEN) {
-        usbd_ep_stall(usbd, 0);
-
-        return;
-    }
-
-    USBCore().hexDump('^', (uint8_t *)&usbd->control.req, 8);
-
-    this->maxWrite = usbd->control.req.wLength;
-    switch (usbd->control.req.bmRequestType & USB_REQTYPE_MASK) {
-        /* standard device request */
-        case USB_REQTYPE_STRD:
-            if (usbd->control.req.bRequest == USB_GET_DESCRIPTOR
-                && (usbd->control.req.bmRequestType & USB_RECPTYPE_MASK) == USB_RECPTYPE_DEV) {
-                if ((usbd->control.req.wValue >> 8) == USB_DESCTYPE_CONFIG) {
-                    this->sendDeviceConfigDescriptor();
-                    reqstat = REQ_SUPP;
-                    break;
-                }
-            }
-            // This calls into ClassCore for class descriptors
-            reqstat = usbd_standard_request(usbd, &usbd->control.req);
-            break;
-
-        /* device class request */
-        case USB_REQTYPE_CLASS:
-            // Calls into class_core->req_process, does nothing else.
-            reqstat = usbd_class_request(usbd, &usbd->control.req);
-            break;
-
-        /* vendor defined request */
-        case USB_REQTYPE_VENDOR:
-            // Does nothing.
-            reqstat = usbd_vendor_request(usbd, &usbd->control.req);
-            break;
-
-        default:
-            break;
-    }
-
-    if (reqstat != REQ_SUPP) {
-        usbd_ep_stall(usbd, 0);
-        return;
-    }
-    if (usbd->control.req.wLength == 0) {
-        /* USB control transfer status in stage */
-        this->sendZLP(usbd, 0);
-        return;
-    }
-    if (usbd->control.req.bmRequestType & USB_TRX_IN) {
-        usbd_ep_send(usbd, 0, usbd->transc_in[0].xfer_buf, usbd->transc_in[0].xfer_len);
-        // _usb_in0_transc will take care of Status OUT
-    } else {
-        usbd->drv_handler->ep_rx_enable(usbd, 0);
-        // _usb_out0_transc will take care of Status IN
-    }
+    this->oldTranscSetup(usbd, ep);
+    USBCore().logEP('.', ep, '^', USB_SETUP_PACKET_LEN);
 }
 
 // Called in interrupt context.
@@ -944,10 +887,11 @@ void USBCore_::transcOut(usb_dev* usbd, uint8_t ep)
 {
     auto transc = &usbd->transc_out[ep];
     auto count = transc->xfer_count;
-    EPBuffers().buf(ep).transcOut();
     USBCore().logEP(':', ep, '<', count);
     if (ep == 0) {
         this->oldTranscOut(usbd, ep);
+    } else {
+        EPBuffers().buf(ep).transcOut();
     }
     USBCore().logEP('.', ep, '<', count);
 }
@@ -957,16 +901,17 @@ void USBCore_::transcIn(usb_dev* usbd, uint8_t ep)
 {
     auto transc = &usbd->transc_in[ep];
     USBCore().logEP(':', ep, '>', transc->xfer_count);
-    EPBuffers().buf(ep).transcIn();
-     if (ep == 0) {
+    if (ep == 0) {
         this->oldTranscIn(usbd, ep);
+    } else {
+        EPBuffers().buf(ep).transcIn();
     }
     transc->xfer_count = 0;
 }
 
-void USBCore_::sendDeviceConfigDescriptor()
+void USBCore_::buildDeviceConfigDescriptor()
 {
-    auto oldMaxWrite = this->maxWrite;
+    this->ctlIdx = 0;
     this->maxWrite = 0;
     uint8_t interfaceCount = 0;
     uint16_t len = 0;
@@ -978,7 +923,7 @@ void USBCore_::sendDeviceConfigDescriptor()
 
     configDesc.wTotalLength = sizeof(configDesc) + len;
     configDesc.bNumInterfaces = interfaceCount;
-    this->maxWrite = oldMaxWrite;
+    this->maxWrite = USBCORE_CTL_BUFSZ;
     this->ctlIdx = 0;
     this->sendControl(0, &configDesc, sizeof(configDesc));
     interfaceCount = 0;
@@ -987,9 +932,8 @@ void USBCore_::sendDeviceConfigDescriptor()
     CDCACM().getInterface();
 #endif
     PluggableUSB().getInterface(&interfaceCount);
-    // TODO: verify this sends ZLP properly when:
-    //   wTotalLength % sizeof(this->buf) == 0
-    this->flush(0);
+    memcpy(this->cfgDesc, this->ctlBuf, this->ctlIdx);
+    USBCore().usbDev().desc->config_desc = this->cfgDesc;
 }
 
 void USBCore_::sendZLP(usb_dev* usbd, uint8_t ep)

--- a/cores/arduino/USBCore.h
+++ b/cores/arduino/USBCore.h
@@ -18,6 +18,13 @@ extern "C" {
 #endif
 
 /*
+ * Default speed for trace logging serial port
+ */
+#ifndef USBCORE_TRACE_SPEED
+#define USBCORE_TRACE_SPEED 230400
+#endif
+
+/*
  * Descriptor for storing an endpoint’s direction, type, and max
  * packet length.
  */
@@ -170,6 +177,10 @@ class USBCore_
 
         uint8_t setupCtlOut(usb_req* req);
         void ctlOut(usb_dev* udev);
+
+        void logEP(char kind, uint8_t ep, char dir, size_t len);
+        void hexDump(char prefix, const uint8_t *buf, size_t len);
+        void logStatus(const char *status);
         /*
          * Static member function helpers called from ISR.
          *

--- a/cores/arduino/USBCore.h
+++ b/cores/arduino/USBCore.h
@@ -176,6 +176,7 @@ class USBCore_
         void setResetHook(void (*hook)());
 
         uint8_t setupCtlOut(usb_req* req);
+        void setupClass(uint16_t wLength);
         void ctlOut(usb_dev* udev);
 
         void logEP(char kind, uint8_t ep, char dir, size_t len);
@@ -190,6 +191,8 @@ class USBCore_
         static void transcSetupHelper(usb_dev* usbd, uint8_t ep);
         static void transcOutHelper(usb_dev* usbd, uint8_t ep);
         static void transcInHelper(usb_dev* usbd, uint8_t ep);
+
+        void buildDeviceConfigDescriptor();
 
         /*
          * Shadow the global ‘usbd’, which shouldn't be used directly,
@@ -217,6 +220,8 @@ class USBCore_
         // Transfer size for setCtlOutDest
         size_t ctlOutLen;
 
+        uint8_t cfgDesc[USBCORE_CTL_BUFSZ];
+
         /*
          * Pointers to the transaction routines specified by ‘usbd_init’.
          */
@@ -227,8 +232,6 @@ class USBCore_
         void transcSetup(usb_dev* usbd, uint8_t ep);
         void transcOut(usb_dev* usbd, uint8_t ep);
         void transcIn(usb_dev* usbd, uint8_t ep);
-
-        void sendDeviceConfigDescriptor();
 
         void sendZLP(usb_dev* usbd, uint8_t ep);
 };


### PR DESCRIPTION
Construct the USB configuration descriptor set on USB reset and save it for later, instead of constructing it each time there is a request.

This allows us to use the vendor firmware to respond to almost all of the standard USB requests, which means we can remove a lot of code that duplicated large parts of the vendor firmware.

This is based on #28, and is set to draft in case the previous PR needs revision.