### PR TITLE
avoid race condition in usbd_ep_send

### DIFF
--- a/system/GD32F30x_firmware/GD32F30x_usbd_library/device/Source/usbd_core.c
+++ b/system/GD32F30x_firmware/GD32F30x_usbd_library/device/Source/usbd_core.c
@@ -123,9 +123,11 @@ void usbd_ep_send (usb_dev *udev, uint8_t ep_addr, uint8_t *pbuf, uint16_t buf_l
 
     uint16_t len = USB_MIN(buf_len, transc->max_len);
 
-    /* configure the transaction level parameters */
+    /*
+     * bugfix: configure transaction for next packet, because ISR can fire
+     * before ep_write returns
+     */
+    usb_transc_config(transc, pbuf + len, buf_len - len, len);
 
     udev->drv_handler->ep_write(pbuf, ep_num, len);
-
-    usb_transc_config(transc, pbuf + len, buf_len - len, len);
 }


### PR DESCRIPTION
Fix a race condition bug in the vendor firmware that could cause the ISR to overwrite `transc` before it's properly configured.

Fixes #33