### PR TITLE
delay clearing EP_RX_ST

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -871,8 +871,7 @@ usb_dev& USBCore_::usbDev()
 void USBCore_::transcSetup(usb_dev* usbd, uint8_t ep)
 {
     USBCore().logEP(':', ep, '^', USB_SETUP_PACKET_LEN);
-    auto count = usbd->drv_handler->ep_read((uint8_t *)(&usbd->control.req), 0, (uint8_t)EP_BUF_SNG);
-    USBCore().hexDump('^', (uint8_t *)&usbd->control.req, count);
+    USBCore().hexDump('^', (uint8_t *)&usbd->control.req, USB_SETUP_PACKET_LEN);
 
     this->oldTranscSetup(usbd, ep);
     USBCore().logEP('.', ep, '^', USB_SETUP_PACKET_LEN);

--- a/system/GD32F30x_firmware/GD32F30x_usbd_library/device/Source/usbd_transc.c
+++ b/system/GD32F30x_firmware/GD32F30x_usbd_library/device/Source/usbd_transc.c
@@ -56,13 +56,13 @@ void _usb_setup_transc (usb_dev *udev, uint8_t ep_num)
 
     usb_reqsta reqstat = REQ_NOTSUPP;
 
-    uint16_t count = udev->drv_handler->ep_read((uint8_t *)(&udev->control.req), 0U, (uint8_t)EP_BUF_SNG);
+    /* bugfix: read packet in ISR instead of here */
 
-    if (count != USB_SETUP_PACKET_LEN) {
-        usb_stall_transc(udev);
-
-        return;
-    }
+    /*
+     * bugfix: force to IDLE state, to cancel actions by any pending
+     * completion handlers
+     */
+    udev->control.ctl_state = USBD_CTL_IDLE;
 
     switch (udev->control.req.bmRequestType & USB_REQTYPE_MASK) {
     /* standard device request */


### PR DESCRIPTION
Avoid a race condition by delaying clearing EP_RX_ST on EP0 until the packet buffer has been read.

The RX_ST flag "freezes" the SETUP flag. (This is not officially documented.) If RX_ST is cleared, an incoming OUT packet can apparently reset the SETUP flag, even if the peripheral answers it with a NAK. This can cause the SETUP packet to be processed as an OUT packet, resulting in application misbehavior.

Fixes #43.