### PR TITLE
add USB TX double buffering

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -205,6 +205,7 @@ size_t EPBuffer<L>::sendSpace()
 template<size_t L>
 void EPBuffer<L>::flush()
 {
+    assert(this->ep != 0);
     usb_disable_interrupts();
     // Don't flush an empty buffer
     if (this->len() == 0) {
@@ -230,10 +231,7 @@ void EPBuffer<L>::flush()
     switch (USBCore().usbDev().cur_status) {
     case USBD_DEFAULT:
     case USBD_ADDRESSED:
-        if (this->ep != 0) {
-            break;
-        }
-    // fall through
+        break;
     case USBD_CONFIGURED:
     case USBD_SUSPENDED: {
         // This will temporarily reenable and disable interrupts
@@ -769,6 +767,9 @@ int USBCore_::send(uint8_t ep, const void* data, int len)
     // Top nybble is used for flags.
     auto flags = ep & 0xf0;
     ep &= 0x7;
+    if (ep == 0) {
+        return -1;
+    }
     auto wrote = 0;
     auto usbd = &USBCore().usbDev();
 

--- a/cores/arduino/USBCore.h
+++ b/cores/arduino/USBCore.h
@@ -100,12 +100,6 @@ class EPBuffer
         void transcOut();
 
         /*
-         * Busy loop until the endpoint has finished its current
-         * transmission.
-         */
-        bool waitForWriteComplete();
-
-        /*
          * Flag for whether we are waiting for data from the host.
          *
          * If this is ‘true’, there is no data available in the
@@ -126,10 +120,8 @@ class EPBuffer
         volatile uint8_t* tail = buf;
         volatile uint8_t* p = buf;
 
-        /*
-         * Prevent more than one simultaneous call to ‘flush’.
-         */
-        volatile bool currentlyFlushing = false;
+        /* whether the buf contents are already waiting on another flush */
+        volatile bool pendingFlush = false;
 
         uint8_t ep;
 };


### PR DESCRIPTION
Add double buffering for USB transmissions, to match the AVR core behavior. This is emulated, because the GD32 USBD peripheral only supports hardware double buffering for bulk and isochronous endpoints.

Fixes #39.