### PR TITLE
use ACK timeout for STOP

### DIFF
--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -68,8 +68,9 @@ static struct i2c_s *obj_s_buf[I2C_NUM] = {NULL};
 #define WIRE_I2C_FLAG_TIMEOUT_START WIRE_I2C_FLAG_TIMEOUT
 #endif
 
+/* Because some targets stretch the clock after ACKing the last byte */
 #ifndef WIRE_I2C_FLAG_TIMEOUT_STOP_BIT_RESET
-#define WIRE_I2C_FLAG_TIMEOUT_STOP_BIT_RESET WIRE_I2C_FLAG_TIMEOUT
+#define WIRE_I2C_FLAG_TIMEOUT_STOP_BIT_RESET WIRE_I2C_ACK_TIMEOUT
 #endif
 
 #ifndef WIRE_I2C_FLAG_TIMEOUT_ADDR_ACK


### PR DESCRIPTION
Some targets stretch the clock after ACKing the last byte, which means that sending a STOP signal can time out if we use the short timeout.

This doesn't seem to cause problems in practice, but I did notice an old debug breakpoint firing more often than it should (when tracking down something else).