### PR TITLE
fix receiving ZLP

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -281,8 +281,24 @@ void EPBuffer<L>::enableOutEndpoint()
 template<size_t L>
 void EPBuffer<L>::transcOut()
 {
-    this->tail = this->buf + USBCore().usbDev().transc_out[this->ep].xfer_count;;
+    auto count = USBCore().usbDev().transc_out[this->ep].xfer_count;
+    this->tail = this->buf + count;
+    // Reset rxWaiting now so enableOutEndpoint works properly for ZLPs
     this->rxWaiting = false;
+    if (count == 0) {
+        /*
+         * Got a ZLP; re-enable endpoint so we don't stop accepting input! If
+         * the application is polling available() instead of calling recv(), it
+         * would otherwise never execute pop(). This means that the endpoint
+         * would remain disabled, and the driver would keep sending NAK to the
+         * host when the host sends more data, causing an apparent lockup.
+         *
+         * Background: Hosts can send a ZLP if sending data that's exactly a
+         * multiple of wMaxPacketSize (which is 64 bytes for full-speed USB).
+         * At least some versions of macOS do this.
+         */
+        this->enableOutEndpoint();
+    }
 }
 
 // Must be called via ISR


### PR DESCRIPTION
Correctly handle zero-length packets by re-enabling receive. The API doesn't have a reliable way to signal receiving data of zero length. This meant that the application might not ever read the (empty) data, causing the endpoint to lock up and stop accepting more data. Re-enabling receive "early" for ZLPs fixes this problem.

Some hosts send a zero-length packet when sending data that's a multiple of wMaxPacketSize (64 bytes on full-speed USB). This includes at least some versions of macOS. USB generally uses short packets as a signal of end of transmission, which includes sending ZLPs if the data is a both multiple of wMaxPacketSize and less data than the receiver was expecting. Because the host might not know the size of the device's receive buffer, it might send a ZLP following a transmission that ends with a max-length packet, to ensure that the device receives it promptly.