### PR TITLE
fix sending ZLP

### DIFF
--- a/cores/arduino/USBCore.h
+++ b/cores/arduino/USBCore.h
@@ -123,6 +123,9 @@ class EPBuffer
         /* whether the buf contents are already waiting on another flush */
         volatile bool pendingFlush = false;
 
+        /* whether flushing an empty buffer will result in a ZLP */
+        volatile bool sendZLP = false;
+
         uint8_t ep;
 };
 


### PR DESCRIPTION
Send a ZLP when flushing after sending a full packet.

Some versions on Windows won't always see output that's a multiple of wMaxPacketSize if there's no ZLP at the end.