### PR TITLE
defer 1200bps reboot

### DIFF
--- a/cores/arduino/CDCACM.h
+++ b/cores/arduino/CDCACM.h
@@ -102,6 +102,7 @@ class CDCACM_ : public Stream
         size_t write(const uint8_t* d, size_t len);
         void flush();
         using Print::write;
+        void ctlIn();
 
     private:
         uint8_t acmInterface;
@@ -130,6 +131,7 @@ class CDCACM_ : public Stream
         // We only store one octet, but up to 16 bits to have a flag that
         // specifies whether or not a character has been read.
         volatile int16_t peekBuffer = -1;
+        bool do_reboot = false;
 };
 
 #ifdef USBD_USE_CDC

--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -511,6 +511,8 @@ class ClassCore
         static uint8_t ctlIn(usb_dev* usbd)
         {
             (void)usbd;
+            // CDCACM deferred action for 1200bps touch reboot
+            CDCACM().ctlIn();
             return REQ_SUPP;
         }
 


### PR DESCRIPTION
Defer the actual reboot from 1200bps touch until after the control transfer completes. Previously, the reboot occurred before the Control IN handshake stage of the control transfer completed.

This prevents some spurious (but harmless) error messages that some people saw on Linux.